### PR TITLE
Fix the server interceptor

### DIFF
--- a/lib/grpc_newrelic_interceptor/server_interceptor.rb
+++ b/lib/grpc_newrelic_interceptor/server_interceptor.rb
@@ -49,13 +49,13 @@ module GrpcNewrelicInterceptor
     # @param [Method] method
     # @return [String]
     def get_service_name(method)
-      method.owner.service_name
+      method.receiver.class.service_name
     end
 
     # @param [Method] method
     # @return [String]
     def get_partial_name(method)
-      "#{method.owner.name}/#{method.name}"
+      "#{method.receiver.class.name}/#{method.name}"
     end
 
     # @param [Method] method


### PR DESCRIPTION
## Why

Although `method.owner` returns the receiver class in most cases, it does not work if the method was overridden
by some prepended modules.

## What

Replace `method.owner` with `method.receiver.class`. The former returns the receiver class even though
the method is overwritten.